### PR TITLE
Update ayu-light.json to highlight selected tab

### DIFF
--- a/ayu-light.json
+++ b/ayu-light.json
@@ -88,7 +88,7 @@
 		"editorGroupHeader.tabsBackground": "#fafafa",
 		"editorGroupHeader.noTabsBackground": "#fafafa",
 		"editorGroupHeader.tabsBorder": "#e2e4e7",
-		"tab.activeBackground": "#fafafa",
+		"tab.activeBackground": "#f2f2f2",
 		"tab.inactiveBackground": "#fafafa",
 		"tab.activeForeground": "#5c6773",
 		"tab.inactiveForeground": "#828c99",


### PR DESCRIPTION
Hello,
It is hard to determine the open tab. So this PR tries to address that by setting the color for selected tab. The color used is same as the one used for other cases like current line etc. So this helps maintain consistency.