### PR TITLE
feat: mts extension

### DIFF
--- a/ayu-icons.json
+++ b/ayu-icons.json
@@ -535,6 +535,7 @@
     "tikz": "matlab",
     "ts": "typescript",
     "tsx": "typescript",
+    "mts": "typescript",
     "ttf": "font",
     "twig": "twig",
     "txt": "text",


### PR DESCRIPTION
This pull request adds support for the `mts` file extension in the `ayu-icons.json` configuration, mapping it to the TypeScript icon. This ensures that `.mts` files are visually identified as TypeScript files in the UI.

<img width="196" height="108" alt="Screenshot 2025-11-09 at 13 37 23" src="https://github.com/user-attachments/assets/f6d973d5-df10-4da5-81e1-86201202511a" />

https://www.totaltypescript.com/concepts/mjs-cjs-mts-and-cts-extensions
